### PR TITLE
WIP:  Allow for prebuilt docker image

### DIFF
--- a/.github/workflows/ci-simple.yml
+++ b/.github/workflows/ci-simple.yml
@@ -21,7 +21,7 @@ jobs:
           chroot: fedora-39-x86_64
           spec: test/simple/simple.spec
       - name: Build rpm
-        uses: jw3/mock-rpm@v0
+        uses: bschonec/mock-rpm@prebuilt_docker_image
         with:
           chroot: fedora-39-x86_64
           srpm: simple-*.src.rpm

--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ jobs:
 
 ## Inputs
 
-| Name       | Required | Default | Description                                                                                                     |
-|------------|----------|---------|-----------------------------------------------------------------------------------------------------------------|
-| **chroot** | Y        |         | Mock chroot id ([_list_](https://github.com/rpm-software-management/mock/tree/main/mock-core-configs/etc/mock)) |
-| **spec**   | Y        |         | Path to spec file                                                                                               |
-| **src**    | N        |         | Path (file or dir) mapped to the rpmbuild/SOURCES directory                                                     |
+| Name       | Required | Default      | Description                                                                                                     |
+|------------|----------|--------------|-----------------------------------------------------------------------------------------------------------------|
+| **chroot** | Y        |              | Mock chroot id ([_list_](https://github.com/rpm-software-management/mock/tree/main/mock-core-configs/etc/mock)) |
+| **spec**   | Y        |              | Path to spec file                                                                                               |
+| **src**    | N        |              | Path (file or dir) mapped to the rpmbuild/SOURCES directory                                                     |
+| **image**  | N        |fedora:latest | Docker image on which to run mock builds.                                                                       |
 
 
 

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
       shell: bash
 
     - id: create-container
-      run: podman run -dt --dns=8.8.8.8 --privileged $(cat /tmp/mock-container-args) -v ${{ inputs.result-dir }}:/out ${{ inputs.image }} > action.cid
+      run: podman run -dt --privileged $(cat /tmp/mock-container-args) -v ${{ inputs.result-dir }}:/out ${{ inputs.image }} > action.cid
       shell: bash
 
     # Skip this job if ${{ inputs.image }} is not the default.  It is expected that any pre-built Docker image

--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
         podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec
         podman exec $cid dnf -y install mlocate
-        podman exec $cid updatedb; locate apache
+        podman exec $cid /usr/sbin/updatedb; locate apache
         #
         #
         #/builddir/build/SPECS

--- a/action.yml
+++ b/action.yml
@@ -63,8 +63,8 @@ runs:
     - id: init-mock-env
       run: |
         cid=$(cat action.cid)
-        podman exec $cid dnf install -y mock
-        podman exec $cid mock -r ${{ inputs.chroot }} --init
+        podman exec $cid 'mock || dnf install -y mock'
+        #podman exec $cid mock -r ${{ inputs.chroot }} --init
       shell: bash
       if: ${{ inputs.image }} == 'fedora:latest'
 

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,7 @@ runs:
         spec=$(basename ${{ inputs.spec }})
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
         podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec $spec /builddir/build/SPECS
+        ls -l /builddir/build/SPECS
       shell: bash
 
     - id: build

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
         podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec
         #
         #/builddir/build/SPECS
-        yum -y install mlocate; updatedb
+        dnf -y install mlocate; updatedb
         locate apache
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -83,8 +83,11 @@ runs:
         cid=$(cat action.cid)
         spec=$(basename ${{ inputs.spec }})
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
-        podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec /builddir/build/SPECS
-        ls -l /builddir/build/SPECS
+        podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec
+        #
+        #/builddir/build/SPECS
+        yum -y install mlocate; updatedb
+        locate apache
       shell: bash
 
     - id: build

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
       shell: bash
 
     - id: create-container
-      run: podman run -dt --network='host' --privileged $(cat /tmp/mock-container-args) -v ${{ inputs.result-dir }}:/out ${{ inputs.image }} > action.cid
+      run: podman run -dt --privileged $(cat /tmp/mock-container-args) -v ${{ inputs.result-dir }}:/out ${{ inputs.image }} > action.cid
       shell: bash
 
     # Skip this job if ${{ inputs.image }} is not the default.  It is expected that any pre-built Docker image

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,4 @@
-name: mock srpm build
-author: John Wass
+author: jw3
 description: Action for simple chroot building of source RPMs
 branding:
   icon: package
@@ -13,11 +12,10 @@ inputs:
     description: Path to spec file
     required: true
   src:
-    description: Source file or directory
-    required: true
-    default: .
+    description: Path (file or dir) mapped to the rpmbuild/SOURCES directory
+    required: false
   result-dir:
-    description: Show mock logs
+    description: Target path for writing build artifacts
     required: true
     default: .
   image:
@@ -32,10 +30,31 @@ runs:
       run: sudo apt install -y podman
       shell: bash
 
-    - id: create-container
+    - id: prep-fs
       run: |
+        touch /tmp/mock-container-args
         mkdir -p ${{ inputs.result-dir }}
-        podman run -dt --privileged -v ${{ inputs.src }}:/in:ro -v ${{ inputs.result-dir }}:/out ${{ inputs.image }} > action.cid
+      shell: bash
+
+    - id: map-source
+      if: inputs.src != null
+      run: |
+        src="${{ inputs.src }}"
+        if [[ "$src" != /* ]]; then src="${{ github.workspace }}/$src"; fi 
+        if [[ -d ${src} ]]; then
+          arg="-v $src:/in:ro"
+        elif [[ -f ${src} ]]; then
+          fname=$(basename "${src}")
+          arg="-v $src:/in/$fname:ro"
+        else
+          echo "$src does not exist"
+          exit 1
+        fi
+        echo -n "$arg" > /tmp/mock-container-args
+      shell: bash
+
+    - id: create-container
+      run: podman run -dt --privileged $(cat /tmp/mock-container-args) -v ${{ inputs.result-dir }}:/out ${{ inputs.image }} > action.cid
       shell: bash
 
     # Skip this job if ${{ inputs.image }} is not the default.  It is expected that any pre-built Docker image
@@ -48,13 +67,32 @@ runs:
       shell: bash
       if: ${{ inputs.image }} == 'fedora:latest'
 
-    - id: build
+    - id: copy-in-sources
+      if: inputs.src != null
+      run: |
+        cid=$(cat action.cid)
+        for f in $(podman exec $cid ls /in); do
+          podman exec $cid mock -r ${{ inputs.chroot }} --copyin /in/$f /builddir/build/SOURCES
+        done
+      shell: bash
+
+    - id: copy-in-specs
       run: |
         cid=$(cat action.cid)
         spec=$(basename ${{ inputs.spec }})
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
         podman exec $cid mock -r ${{ inputs.chroot }} --copyin /tmp/$spec /builddir/build/SPECS
-        podman exec $cid mock -r ${{ inputs.chroot }} --copyin /in /builddir/build/SOURCES
+      shell: bash
+
+    - id: build
+      run: |
+        cid=$(cat action.cid)
+        spec=$(basename ${{ inputs.spec }})
         podman exec $cid mock -r ${{ inputs.chroot }} --shell rpmbuild -bs /builddir/build/SPECS/$spec
+      shell: bash
+
+    - id: copy-out
+      run: |
+        cid=$(cat action.cid)
         podman exec $cid mock -r ${{ inputs.chroot }} --copyout /builddir/build/SRPMS/* /out
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
         podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec
         podman exec $cid dnf -y install mlocate
-        podman exec $cid rpm -qil plocate
+        podman exec $cid /usr/bin/locate apache
         #
         #
         #/builddir/build/SPECS

--- a/action.yml
+++ b/action.yml
@@ -82,10 +82,9 @@ runs:
       run: |
         cid=$(cat action.cid)
         spec=$(basename ${{ inputs.spec }})
-        podman exec ${{ inputs.spec }} dnf -y install mlocate; updatedb
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
         podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec
-        podman exec ${{ inputs.spec }} dnf -y install mlocate; updatedb; locate apache
+        podman exec $cid dnf -y install mlocate; updatedb; locate apache
         #
         #/builddir/build/SPECS
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: mock srpm build
-author: jw3
+author: John Wass
 description: Action for simple chroot building of source RPMs
 branding:
   icon: package
@@ -13,12 +13,17 @@ inputs:
     description: Path to spec file
     required: true
   src:
-    description: Path (file or dir) mapped to the rpmbuild/SOURCES directory
-    required: false
-  result-dir:
-    description: Target path for writing build artifacts
+    description: Source file or directory
     required: true
     default: .
+  result-dir:
+    description: Show mock logs
+    required: true
+    default: .
+  image:
+    description: Pre-built Docker image to run instead of default.
+    required: true
+    default: 'fedora:latest'
 
 runs:
   using: composite
@@ -27,66 +32,29 @@ runs:
       run: sudo apt install -y podman
       shell: bash
 
-    - id: prep-fs
-      run: |
-        touch /tmp/mock-container-args
-        mkdir -p ${{ inputs.result-dir }}
-      shell: bash
-
-    - id: map-source
-      if: inputs.src != null
-      run: |
-        src="${{ inputs.src }}"
-        if [[ "$src" != /* ]]; then src="${{ github.workspace }}/$src"; fi 
-        if [[ -d ${src} ]]; then
-          arg="-v $src:/in:ro"
-        elif [[ -f ${src} ]]; then
-          fname=$(basename "${src}")
-          arg="-v $src:/in/$fname:ro"
-        else
-          echo "$src does not exist"
-          exit 1
-        fi
-        echo -n "$arg" > /tmp/mock-container-args
-      shell: bash
-
     - id: create-container
-      run: podman run -dt --privileged $(cat /tmp/mock-container-args) -v ${{ inputs.result-dir }}:/out fedora:latest > action.cid
+      run: |
+        mkdir -p ${{ inputs.result-dir }}
+        podman run -dt --privileged -v ${{ inputs.src }}:/in:ro -v ${{ inputs.result-dir }}:/out ${{ inputs.docker-image }} > action.cid
       shell: bash
 
+    # Skip this job if ${{ inputs.docker-image }} is not the default.  It is expected that any pre-built Docker image
+    # will have mock installed and configured ahead of time.
     - id: init-mock-env
       run: |
         cid=$(cat action.cid)
         podman exec $cid dnf install -y mock
         podman exec $cid mock -r ${{ inputs.chroot }} --init
       shell: bash
-
-    - id: copy-in-sources
-      if: inputs.src != null
-      run: |
-        cid=$(cat action.cid)
-        for f in $(podman exec $cid ls /in); do
-          podman exec $cid mock -r ${{ inputs.chroot }} --copyin /in/$f /builddir/build/SOURCES
-        done
-      shell: bash
-
-    - id: copy-in-specs
-      run: |
-        cid=$(cat action.cid)
-        spec=$(basename ${{ inputs.spec }})
-        podman cp ${{ inputs.spec }} $cid:/tmp/$spec
-        podman exec $cid mock -r ${{ inputs.chroot }} --copyin /tmp/$spec /builddir/build/SPECS
-      shell: bash
+      if: ${{ inputs.image }} == 'fedora:latest'
 
     - id: build
       run: |
         cid=$(cat action.cid)
         spec=$(basename ${{ inputs.spec }})
+        podman cp ${{ inputs.spec }} $cid:/tmp/$spec
+        podman exec $cid mock -r ${{ inputs.chroot }} --copyin /tmp/$spec /builddir/build/SPECS
+        podman exec $cid mock -r ${{ inputs.chroot }} --copyin /in /builddir/build/SOURCES
         podman exec $cid mock -r ${{ inputs.chroot }} --shell rpmbuild -bs /builddir/build/SPECS/$spec
-      shell: bash
-
-    - id: copy-out
-      run: |
-        cid=$(cat action.cid)
         podman exec $cid mock -r ${{ inputs.chroot }} --copyout /builddir/build/SRPMS/* /out
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -82,9 +82,11 @@ runs:
       run: |
         cid=$(cat action.cid)
         spec=$(basename ${{ inputs.spec }})
+        podman exec $cid dnf -y install mlocate
+        podman exec $cid /usr/sbin/updatedb
+        podman exec $cid /usr/bin/locate apache
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
         podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec
-        podman exec $cid dnf -y install mlocate
         podman exec $cid /usr/sbin/updatedb
         podman exec $cid /usr/bin/locate apache
         #

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
         cid=$(cat action.cid)
         spec=$(basename ${{ inputs.spec }})
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
-        podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec $spec /builddir/build/SPECS
+        podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec /builddir/build/SPECS
         ls -l /builddir/build/SPECS
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
       if: ${{ inputs.image }} == 'fedora:latest'
 
     - id: copy-in-sources
-      if: inputs.src != null
+      #if: inputs.src != null
       run: |
         cid=$(cat action.cid)
         for f in $(podman exec $cid ls /in); do

--- a/action.yml
+++ b/action.yml
@@ -1,3 +1,4 @@
+name: mock srpm build
 author: jw3
 description: Action for simple chroot building of source RPMs
 branding:

--- a/action.yml
+++ b/action.yml
@@ -35,10 +35,10 @@ runs:
     - id: create-container
       run: |
         mkdir -p ${{ inputs.result-dir }}
-        podman run -dt --privileged -v ${{ inputs.src }}:/in:ro -v ${{ inputs.result-dir }}:/out ${{ inputs.docker-image }} > action.cid
+        podman run -dt --privileged -v ${{ inputs.src }}:/in:ro -v ${{ inputs.result-dir }}:/out ${{ inputs.image }} > action.cid
       shell: bash
 
-    # Skip this job if ${{ inputs.docker-image }} is not the default.  It is expected that any pre-built Docker image
+    # Skip this job if ${{ inputs.image }} is not the default.  It is expected that any pre-built Docker image
     # will have mock installed and configured ahead of time.
     - id: init-mock-env
       run: |

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
       run: |
         cid=$(cat action.cid)
         podman exec $cid dnf install -y mock
-        #podman exec $cid mock -r ${{ inputs.chroot }} --init
+        podman exec $cid mock -r ${{ inputs.chroot }} --init
       shell: bash
       if: ${{ inputs.image }} == 'fedora:latest'
 

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
         cid=$(cat action.cid)
         spec=$(basename ${{ inputs.spec }})
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
-        podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec /builddir/build/SPECS
+        podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec $spec /builddir/build/SPECS
       shell: bash
 
     - id: build

--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
         podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec
         podman exec $cid dnf -y install mlocate
-        podman exec $cid /usr/sbin/updatedb; locate apache
+        podman exec $cid /usr/sbin/updatedb; /usr/bin/locate apache
         #
         #
         #/builddir/build/SPECS

--- a/action.yml
+++ b/action.yml
@@ -82,12 +82,12 @@ runs:
       run: |
         cid=$(cat action.cid)
         spec=$(basename ${{ inputs.spec }})
+        podman exec ${{ inputs.spec }} dnf -y install mlocate; updatedb
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
         podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec
+        podman exec ${{ inputs.spec }} dnf -y install mlocate; updatedb; locate apache
         #
         #/builddir/build/SPECS
-        dnf -y install mlocate; updatedb
-        locate apache
       shell: bash
 
     - id: build

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
       shell: bash
 
     - id: create-container
-      run: podman run -dt --privileged $(cat /tmp/mock-container-args) -v ${{ inputs.result-dir }}:/out ${{ inputs.image }} > action.cid
+      run: podman run -dt --network='host' --privileged $(cat /tmp/mock-container-args) -v ${{ inputs.result-dir }}:/out ${{ inputs.image }} > action.cid
       shell: bash
 
     # Skip this job if ${{ inputs.image }} is not the default.  It is expected that any pre-built Docker image

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - id: install-podman
-      run: sudo apt install -y podman
+      run: sudo dnf install -y podman
       shell: bash
 
     - id: prep-fs

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
       run: |
         cid=$(cat action.cid)
         podman exec $cid dnf install -y mock
-      #  podman exec $cid mock -r ${{ inputs.chroot }} --init
+        podman exec $cid mock -r ${{ inputs.chroot }} --init
       shell: bash
       if: ${{ inputs.image }} == 'fedora:latest'
 
@@ -76,13 +76,14 @@ runs:
           podman exec $cid mock -r ${{ inputs.chroot }} --copyin /in/$f /builddir/build/SOURCES
         done
       shell: bash
+      if: false
 
     - id: copy-in-specs
       run: |
         cid=$(cat action.cid)
         spec=$(basename ${{ inputs.spec }})
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
-        podman exec $cid mock -r ${{ inputs.chroot }} --copyin /tmp/$spec /builddir/build/SPECS
+        podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec /builddir/build/SPECS
       shell: bash
 
     - id: build
@@ -91,9 +92,11 @@ runs:
         spec=$(basename ${{ inputs.spec }})
         podman exec $cid mock -r ${{ inputs.chroot }} --shell rpmbuild -bs /builddir/build/SPECS/$spec
       shell: bash
+      if: false
 
     - id: copy-out
       run: |
         cid=$(cat action.cid)
         podman exec $cid mock -r ${{ inputs.chroot }} --copyout /builddir/build/SRPMS/* /out
       shell: bash
+      if: false

--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
         podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec
         podman exec $cid dnf -y install mlocate
-        podman exec $cid /usr/sbin/updatedb; /usr/bin/locate apache
+        podman exec $cid rpm -qil plocate
         #
         #
         #/builddir/build/SPECS

--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,7 @@ runs:
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
         podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec
         podman exec $cid dnf -y install mlocate
+        podman exec $cid /usr/sbin/updatedb
         podman exec $cid /usr/bin/locate apache
         #
         #

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
       shell: bash
 
     - id: create-container
-      run: podman run -dt --privileged $(cat /tmp/mock-container-args) -v ${{ inputs.result-dir }}:/out ${{ inputs.image }} > action.cid
+      run: podman run -dt --dns=8.8.8.8 --privileged $(cat /tmp/mock-container-args) -v ${{ inputs.result-dir }}:/out ${{ inputs.image }} > action.cid
       shell: bash
 
     # Skip this job if ${{ inputs.image }} is not the default.  It is expected that any pre-built Docker image

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,9 @@ runs:
         spec=$(basename ${{ inputs.spec }})
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
         podman exec $cid mock -r ${{ inputs.chroot }} --copyin --clean --buildsrpm --config-opts='use_host_resolv=True' --config-opts='rpmbuild_networking=True' --define='_disable_source_fetch 0' --spec /tmp/$spec
-        podman exec $cid dnf -y install mlocate; updatedb; locate apache
+        podman exec $cid dnf -y install mlocate
+        podman exec $cid updatedb; locate apache
+        #
         #
         #/builddir/build/SPECS
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
       run: |
         cid=$(cat action.cid)
         podman exec $cid dnf install -y mock
-        podman exec $cid mock -r ${{ inputs.chroot }} --init
+      #  podman exec $cid mock -r ${{ inputs.chroot }} --init
       shell: bash
       if: ${{ inputs.image }} == 'fedora:latest'
 

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
     - id: init-mock-env
       run: |
         cid=$(cat action.cid)
-        podman exec $cid 'mock || dnf install -y mock'
+        podman exec $cid dnf install -y mock
         #podman exec $cid mock -r ${{ inputs.chroot }} --init
       shell: bash
       if: ${{ inputs.image }} == 'fedora:latest'


### PR DESCRIPTION
This pull request will allow for the operator to use his own Docker image which may be preconfigured with mock and mock environments.

Using a pre-configured Docker image decreases the run time by about two minutes; which can be a significant time saver when doing testing.

Let me know your thoughts.  I see you have another PR #6 out there that seems to follow the same thinking.  I've included a Dockerfile as well but I haven't yet made changes to the README.md to reflect how to build the image correctly (using the --privileged flag).

Of course, my changes in ci-simple.yml refer to MY branch.  This is somewhat of a chicken-egg issue and will have to be changed to your project if you accept the changes.