### PR TITLE
Fetch remote sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ jobs:
 
 ## Inputs
 
-| Name           | Required | Default            | Description                                                                                                     |
-|----------------|----------|--------------------|-----------------------------------------------------------------------------------------------------------------|
-| **chroot**     | Y        |                    | Mock chroot id ([_list_](https://github.com/rpm-software-management/mock/tree/main/mock-core-configs/etc/mock)) |
-| **spec**       | Y        |                    | Path to spec file                                                                                               |
-| **sources**    | N        |                    | Path (file or dir) mapped to the rpmbuild/SOURCES directory                                                     |
-| **cache**      | N        |                    | Enable chroot environment caching                                                                               |
-| **image**      | N        | `fedora:latest`    | Container image for Mock execution                                                                              |
-| **result-dir** | Y        | `github.workspace` | Target path for writing build artifacts                                                                         |
+| Name                | Required | Default            | Description                                                                                                     |
+|---------------------|----------|--------------------|-----------------------------------------------------------------------------------------------------------------|
+| **chroot**          | Y        |                    | Mock chroot id ([_list_](https://github.com/rpm-software-management/mock/tree/main/mock-core-configs/etc/mock)) |
+| **spec**            | Y        |                    | Path to spec file                                                                                               |
+| **sources**         | N        |                    | Path (file or dir) mapped to the rpmbuild/SOURCES directory                                                     |
+| **fetch-sources**   | N        |                    | Use spectool to fetch remote SourceX entries                                                                    |
+| **cache**           | N        |                    | Enable chroot environment caching                                                                               |
+| **image**           | N        | `fedora:latest`    | Container image for Mock execution                                                                              |
+| **result-dir**      | Y        | `github.workspace` | Target path for writing build artifacts                                                                         |
 
 ## Caching
 

--- a/action.yml
+++ b/action.yml
@@ -150,7 +150,7 @@ runs:
       if: inputs.fetch-sources == 'true'
       run: |
         cid=$(cat action.cid)
-        podman exec $cid spectool -g -C /builddir/build/SOURCES /builddir/build/SPECS/$spec
+        podman exec $cid spectool -g -C /builddir/build/SOURCES /tmp/$spec
       shell: bash
 
     - id: build

--- a/action.yml
+++ b/action.yml
@@ -151,6 +151,7 @@ runs:
       run: |
         cid=$(cat action.cid)
         podman exec $cid spectool -g -C /builddir/build/SOURCES /tmp/$spec
+        podman exec $cid du -h /builddir/build/SOURCES/*
       shell: bash
 
     - id: build

--- a/action.yml
+++ b/action.yml
@@ -149,6 +149,8 @@ runs:
     - id: fetch-remote-sources
       if: inputs.fetch-sources == 'true'
       run: |
+        cat /tmp/$spec
+        
         cid=$(cat action.cid)
         mkdir /tmp/fetch
         podman exec $cid spectool -g -C /tmp/fetch /tmp/$spec

--- a/action.yml
+++ b/action.yml
@@ -149,10 +149,8 @@ runs:
     - id: fetch-remote-sources
       if: inputs.fetch-sources == 'true'
       run: |
-        cat /tmp/$spec
-        
         cid=$(cat action.cid)
-        mkdir /tmp/fetch
+        spec=$(basename ${{ inputs.spec }})
         podman exec $cid spectool -g -C /tmp/fetch /tmp/$spec
         podman exec $cid du -h /tmp/fetch/*
         for f in $(podman exec $cid ls /tmp/fetch); do

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   sources:
     description: Path (file or dir) mapped to the rpmbuild/SOURCES directory
     required: false
+  fetch-sources:
+    description: Use spectool to fetch remote sources
+    required: false
   cache:
     description: Enable chroot environment caching
     required: false
@@ -95,6 +98,13 @@ runs:
         fi
       shell: bash
 
+    - id: install-spectool
+      if: inputs.fetch-sources == 'true'
+      run: |
+        cid=$(cat action.cid)
+        podman exec $cid dnf install -y rpmdevtools
+      shell: bash
+
     - id: save-container
       if: inputs.cache == 'true' && steps.install-mock.outputs.completed == 'true'
       run: |
@@ -134,6 +144,13 @@ runs:
         spec=$(basename ${{ inputs.spec }})
         podman cp ${{ inputs.spec }} $cid:/tmp/$spec
         podman exec $cid mock -r ${{ inputs.chroot }} --copyin /tmp/$spec /builddir/build/SPECS
+      shell: bash
+
+    - id: fetch-remote-sources
+      if: inputs.fetch-sources == 'true'
+      run: |
+        cid=$(cat action.cid)
+        podman exec $cid spectool -g -C /builddir/build/SOURCES /builddir/build/SPECS/$spec
       shell: bash
 
     - id: build

--- a/action.yml
+++ b/action.yml
@@ -150,8 +150,12 @@ runs:
       if: inputs.fetch-sources == 'true'
       run: |
         cid=$(cat action.cid)
-        podman exec $cid spectool -g -C /builddir/build/SOURCES /tmp/$spec
-        podman exec $cid du -h /builddir/build/SOURCES/*
+        mkdir /tmp/fetch
+        podman exec $cid spectool -g -C /tmp/fetch /tmp/$spec
+        podman exec $cid du -h /tmp/fetch/*
+        for f in $(podman exec $cid ls /tmp/fetch); do
+          podman exec $cid mock -r ${{ inputs.chroot }} --copyin /tmp/fetch/$f /builddir/build/SOURCES
+        done
       shell: bash
 
     - id: build

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: Path (file or dir) mapped to the rpmbuild/SOURCES directory
     required: false
   fetch-sources:
-    description: Use spectool to fetch remote sources
+    description: Use spectool to fetch remote SourceX entries
     required: false
   cache:
     description: Enable chroot environment caching

--- a/action.yml
+++ b/action.yml
@@ -152,7 +152,6 @@ runs:
         cid=$(cat action.cid)
         spec=$(basename ${{ inputs.spec }})
         podman exec $cid spectool -g -C /tmp/fetch /tmp/$spec
-        podman exec $cid du -h /tmp/fetch/*
         for f in $(podman exec $cid ls /tmp/fetch); do
           podman exec $cid mock -r ${{ inputs.chroot }} --copyin /tmp/fetch/$f /builddir/build/SOURCES
         done


### PR DESCRIPTION
A SourceX that is a remote source will now be fetched by spectool.

The only additional configuration is the `fetch-sources` property that must be set to `true` to enable remote fetch.

e.g. spec

```rpm-spec
Source0: https://github.com/my/repo/archive/refs/tags/v1.0.0.zip
```

e.g. workflow

```yaml
      - uses: jw3/mock-srpm@v1
        with:
          chroot: rocky+epel-8-x86_64
          spec: my.spec
          fetch-sources: true
```

Closes #3
Closes #8